### PR TITLE
404 에러 페이지 헤더 적용 삭제

### DIFF
--- a/application/views/errors/html/error_404.php
+++ b/application/views/errors/html/error_404.php
@@ -30,28 +30,6 @@ defined('BASEPATH') || exit('No direct script access allowed');
     </style>
 </head>
 <body>
-<header class="p-3 text-bg-dark">
-    <div class="container">
-        <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
-            <div class="bg-white text-black p-2 rounded-3 me-3">CI3Board</div>
-            <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-                <li><a href="/board?id=1" class="nav-link px-2 text-white">게시판</a></li>
-            </ul>
-            <div class="text-end">
-                <?php if($this->session->userdata('logged_in')): ?>
-                    <span class="text-white me-3">
-                            <?= $this->session->userdata('user_name') ?>님 환영합니다
-                        </span>
-                    <a href="/logout" class="btn btn-outline-light">로그아웃</a>
-                <?php else: ?>
-                    <a href="/login" class="btn btn-outline-light me-2">로그인</a>
-                    <a href="/register" class="btn btn-warning">가입</a>
-                <?php endif; ?>
-            </div>
-        </div>
-    </div>
-</header>
-
 <div id="container">
     <div class="row w-100 justify-content-center">
         <div class="col-md-8 text-center">


### PR DESCRIPTION
resloved #37 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 404 오류 페이지에서 헤더와 내비게이션 바, 사용자 로그인 상태 표시가 제거되었습니다.  
  * 사이트 제목, 게시판 링크, 로그인/로그아웃/회원가입 버튼이 더 이상 표시되지 않습니다.  
  * 404 메시지와 본문, 푸터는 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->